### PR TITLE
Added option to exclude files from checksum

### DIFF
--- a/checksumdir/__init__.py
+++ b/checksumdir/__init__.py
@@ -26,10 +26,13 @@ HASH_FUNCS = {
 }
 
 
-def dirhash(dirname, hashfunc='md5'):
+def dirhash(dirname, hashfunc='md5', excluded_files=None):
     hash_func = HASH_FUNCS.get(hashfunc)
     if not hash_func:
         raise NotImplementedError('{} not implemented.'.format(hashfunc))
+
+    if not excluded_files:
+        excluded_files = []
 
     if not os.path.isdir(dirname):
         raise TypeError('{} is not a directory.'.format(dirname))
@@ -38,7 +41,8 @@ def dirhash(dirname, hashfunc='md5'):
         if not re.search(r'/\.', root):
             hashvalues.extend([_filehash(os.path.join(root, f),
                                          hash_func) for f in files if not
-                               f.startswith('.') and not re.search(r'/\.', f)])
+                               f.startswith('.') and not re.search(r'/\.', f)
+                               and f not in excluded_files])
     return _reduce_hash(hashvalues, hash_func)
 
 

--- a/checksumdir/cli.py
+++ b/checksumdir/cli.py
@@ -23,9 +23,12 @@ def main():
     parser.add_argument('directory', help='Directory to create hash value of')
     parser.add_argument('-a', '--algorithm', choices=('md5', 'sha1', 'sha256',
                                                       'sha512'), default='md5')
+    parser.add_argument('-e', '--excluded-files', nargs='+',
+                        help='List of excluded files')
 
     args = parser.parse_args()
-    print(checksumdir.dirhash(args.directory, args.algorithm))
+    print(checksumdir.dirhash(args.directory, args.algorithm,
+                              args.excluded_files))
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Pass a list of files to be excluded with -e or --excluded-files.
Example: -e this.txt that.ext .andthiscfg
Option still compatible with previous version (new parameter is
optional).
