### PR TITLE
Return a null digest if the file doesn't exist

### DIFF
--- a/checksumdir/__init__.py
+++ b/checksumdir/__init__.py
@@ -67,6 +67,10 @@ def dirhash(dirname, hashfunc='md5', excluded_files=None, ignore_hidden=False,
 def _filehash(filepath, hashfunc):
     hasher = hashfunc()
     blocksize = 64 * 1024
+
+    if not os.path.exists(filepath):
+        return hasher.hexdigest()
+
     with open(filepath, 'rb') as fp:
         while True:
             data = fp.read(blocksize)


### PR DESCRIPTION
For cases where a symlink exists and is pointing to a file which does not exist, an error is thrown when you attempt to open that file because while the path you gave was valid, the file itself cannot be opened by the system.  This changes the behaviour so instead of throwing an error, an empty hex digest is returned instead.

I can't think of another case where `os.walk` will give you a path back that does not exist, so I'm not too concerned about this breaking other behaviour unintentionally.