### PR TITLE
Add option to use stat instead of file bytes.

### DIFF
--- a/checksumdir/__init__.py
+++ b/checksumdir/__init__.py
@@ -25,12 +25,14 @@ HASH_FUNCS = {
     'sha512': hashlib.sha512
 }
 
-
 def dirhash(dirname, hashfunc='md5', excluded_files=None, ignore_hidden=False,
-            followlinks=False, excluded_extensions=None):
+            followlinks=False, excluded_extensions=None, datafunc='deep'):
     hash_func = HASH_FUNCS.get(hashfunc)
+    data_func = DATA_FUNCS.get(datafunc)
     if not hash_func:
         raise NotImplementedError('{} not implemented.'.format(hashfunc))
+    if not data_func:
+        raise NotImplementedError('{} not implemented.'.format(datafunc))
 
     if not excluded_files:
         excluded_files = []
@@ -56,10 +58,21 @@ def dirhash(dirname, hashfunc='md5', excluded_files=None, ignore_hidden=False,
             if fname in excluded_files:
                 continue
 
-            hashvalues.append(_filehash(os.path.join(root, fname), hash_func))
+            hashvalues.append(data_func(os.path.join(root, fname), hash_func))
 
     return _reduce_hash(hashvalues, hash_func)
 
+def _stathash(filepath, hashfunc):
+    hasher = hashfunc()
+    if not os.path.exists(filepath):
+        return hasher.hexdigest()
+
+    statinfo = os.stat(filepath)
+    hasher.update(filepath.encode('UTF-8'))
+
+    for attr in statinfo:
+        hasher.update(str(attr).encode('UTF-8'))
+    return hasher.hexdigest()
 
 def _filehash(filepath, hashfunc):
     hasher = hashfunc()
@@ -76,9 +89,15 @@ def _filehash(filepath, hashfunc):
             hasher.update(data)
     return hasher.hexdigest()
 
-
 def _reduce_hash(hashlist, hashfunc):
     hasher = hashfunc()
     for hashvalue in sorted(hashlist):
         hasher.update(hashvalue.encode('utf-8'))
     return hasher.hexdigest()
+
+DATA_FUNCS = {
+    'shallow': _stathash,
+    'deep': _filehash
+}
+
+

--- a/checksumdir/cli.py
+++ b/checksumdir/cli.py
@@ -31,12 +31,15 @@ def main():
                         help='Follow soft links')
     parser.add_argument('-x', '--excluded-extensions', nargs='+',
                         help='List of excluded file extensions.')
+    parser.add_argument('-d', '--depth', choices=('deep','shallow'), default='deep',
+                        help='Use file bytes (deep) or metadata (shallow) for hashing.')
 
     args = parser.parse_args()
     print(
         checksumdir.dirhash(
             dirname=args.directory,
             hashfunc=args.algorithm,
+            datafunc=args.depth,
             excluded_files=args.excluded_files,
             ignore_hidden=args.ignore_hidden,
             followlinks=args.follow_links,


### PR DESCRIPTION
Calculating the hash of a directory using bytes can get expensive quickly, especially when working with large media files (e.g., videos). This commit adds an option to choose which data source is used to get bytes to be added to the hash, one of:

  - 'deep' (default): read all the bytes in the file into the hash.
  - 'shallow': do a `stat` on the file and use the filename and all values from the `stat`, as returned by `os.stat`.

@cakepietoast I'd be happy to make any changes to this that you deem appropriate, please let me know. Feel free to close this request if the change is unwanted.