### PR TITLE
Include path option is relative to the main folder.

### DIFF
--- a/checksumdir/__init__.py
+++ b/checksumdir/__init__.py
@@ -71,7 +71,7 @@ def dirhash(
             if include_paths:
                 hasher = hash_func()
                 # get the resulting relative path into array of elements
-                path_list = os.path.relpath(os.path.join(root, fname)).split(os.sep)
+                path_list = os.path.relpath(os.path.join(root, fname), dirname).split(os.sep)
                 # compute the hash on joined list, removes all os specific separators
                 hasher.update(''.join(path_list).encode('utf-8'))
                 hashvalues.append(hasher.hexdigest())


### PR DESCRIPTION
Due to this commit we might be sure that the folder structure is considered different when files are in the different subdirectories. For example:

Environment:
```
> mkdir -p /tmp/subdir
> touch /tmp/subdir/a.txt
```

Was:
```
> checksumdir -p /tmp
74be16979710d4c4e7c6647856088456
> checksumdir -p /tmp/subdir
74be16979710d4c4e7c6647856088456
```
The hashes are the same although we are checking `/tmp/subdir/a.txt` in first case and `subdir/a.txt` in the latter.

Now it will be:
```
> checksumdir -p /tmp
f956ecf8ffe9798427114d9b69400ce5
> checksumdir -p /tmp/subdir
0ec539fca957e328003429f8f741c7b1
```

Different checksum, because the relative paths are different.

This way we may find the same folder structure.