### PR TITLE
Replaced pkg_resources with importlib.metadata

### DIFF
--- a/checksumdir/__init__.py
+++ b/checksumdir/__init__.py
@@ -14,9 +14,9 @@ import hashlib
 import os
 import re
 
-import pkg_resources
+from importlib.metadata import version
 
-__version__ = pkg_resources.require("checksumdir")[0].version
+__version__ = version("checksumdir")
 
 HASH_FUNCS = {
     "md5": hashlib.md5,


### PR DESCRIPTION
Use of pkg_resources is discouraged in favor of importlib.resources
and importlib.metadata. importlib.metadata is used in this commit
to get the version string from the pyproject.toml package configuration.

This PR closes #22 in order to hopefully allow PyOxidizer to package the library.